### PR TITLE
refactor: use `ya.emit()` instead of `ya.mgr_emit()`

### DIFF
--- a/easyjump.yazi/main.lua
+++ b/easyjump.yazi/main.lua
@@ -162,7 +162,7 @@ local function read_input_todo(current_num, cursor, offset, first_key_of_label)
       if pos == nil or pos > current_num then
         goto nextkey
       else
-        ya.mgr_emit("arrow", { pos - cursor - 1 + offset })
+        ya.emit("arrow", { pos - cursor - 1 + offset })
         return
       end
     end
@@ -193,7 +193,7 @@ local function read_input_todo(current_num, cursor, offset, first_key_of_label)
       if pos == nil or pos > current_num then -- get the second double key fail, continue to get it
         goto nextkey
       else
-        ya.mgr_emit("arrow", { pos - cursor - 1 + offset })
+        ya.emit("arrow", { pos - cursor - 1 + offset })
         return
       end
     end


### PR DESCRIPTION
`ya.mgr_emit()` is deprecated: https://github.com/sxyazi/yazi/pull/2653