### PR TITLE
ci: test against both nightly and stable yazi versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,18 @@ on:
 
 jobs:
   build:
-    name: Run tests
+    strategy:
+      matrix:
+        yazi-version:
+          - name: nightly
+            method: cargo-install
+            # https://github.com/sxyazi/yazi/commit/c27ef58116794de7f559bca74e60e6e13ae92051 (2025-08-23)
+            commit: c27ef58116794de7f559bca74e60e6e13ae92051
+          - name: stable
+            method: download
+            url: https://github.com/sxyazi/yazi/releases/download/v25.5.28/yazi-x86_64-unknown-linux-gnu.zip
+
+    name: "Test (yazi ${{ matrix.yazi-version.name }})"
     runs-on: ubuntu-latest
 
     steps:
@@ -31,6 +42,7 @@ jobs:
           fzf --version
 
       - name: Compile and install `yazi-fm` from source
+        if: matrix.yazi-version.method == 'cargo-install'
         uses: baptiste0928/cargo-install@v3.3.2
         with:
           # Due to Cargo's limitations, the `yazi-fm` and `yazi-cli` crates on
@@ -38,30 +50,25 @@ jobs:
           # https://github.com/sxyazi/yazi/blob/2ec3a6c645324295331c0f2ef6d4d946cf11c06b/yazi-fm/build.rs?plain=1#L23-L25
           crate: yazi-build
           git: https://github.com/sxyazi/yazi
-          commit:
-            # https://github.com/sxyazi/yazi/commit/c27ef58116794de7f559bca74e60e6e13ae92051 (2025-08-23)
-            c27ef58116794de7f559bca74e60e6e13ae92051
-          # tag: v25.5.31
+          commit: ${{ matrix.yazi-version.commit }}
+          tag: ${{ matrix.yazi-version.tag }}
+
+      - name: Download prebuilt yazi version
+        if: matrix.yazi-version.method == 'download'
+        run: |
+          curl -L ${{ matrix.yazi-version.url }} -o yazi.zip
+          mkdir -p yazi-zip
+          unzip yazi.zip
+          chmod +x yazi-x86_64-unknown-linux-gnu/{yazi,ya}
+          mv -v yazi-x86_64-unknown-linux-gnu/{yazi,ya} $HOME/.cargo/bin/
 
       - name: Make sure yazi and ya are installed
         run: |
-          echo "Cargo binaries:"
-          ls -laR $HOME/.cargo/bin
-
-          echo "cargo-install binaries:"
-          ls -laR $HOME/.cargo-install/
-
           echo "PATH:"
           echo $PATH
 
-          which yazi || {
-            echo "yazi is not installed, but it should be installed by the previous step"
-            exit 1
-          }
-          which ya || {
-            echo "ya is not installed, but it should be installed by the previous step"
-            exit 1
-          }
+          yazi --version
+          ya --version
 
       - uses: pnpm/action-setup@v4.1.0
         with:


### PR DESCRIPTION
# ci: test against both nightly and stable yazi versions

**Issue:**

I want to support the stable and nightly versions of yazi at the same
time.

**Solution:**

Test both versions in the CI. Locally, it's not easy to test both
versions yet, but at least it works in the CI now.