### PR TITLE
test: show yazi logs in the console when a test fails

### DIFF
--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -1,23 +1,55 @@
+import assert from "assert"
 import { defineConfig } from "cypress"
-import fs from "fs"
+import { readdir, readFile } from "fs/promises"
+import path from "path"
+import { inspect } from "util"
 
+const testDirs = path.resolve(__dirname, "test-environment/testdirs")
 export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:3000",
-    video: true,
     setupNodeEvents(on, _config) {
-      on("after:spec", (_spec, results): void => {
-        // https://docs.cypress.io/app/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
-        if (results && results.video) {
-          // Do we have failures for any retry attempts?
-          const failures = results.tests.some((test) => {
-            return test.attempts.some((attempt) => attempt.state === "failed")
+      on("task", {
+        async showYaziLog(): Promise<null> {
+          // find the yazi log file from the last run. There should be only one
+          // because as soon as the test environment is exited, tui-sandbox
+          // removes it. Typically it is in testdirs/abc/.local/state/yazi/yazi.log
+          const files = await readdir(testDirs, {
+            recursive: true,
+            withFileTypes: true,
           })
-          if (!failures && fs.existsSync(results.video)) {
-            // delete the video if the spec passed and no tests retried
-            return fs.unlinkSync(results.video)
+
+          const logFiles = files.filter(
+            (f) => f.isFile() && f.name === "yazi.log",
+          )
+
+          if (logFiles.length === 0) {
+            console.warn("No yazi.log files found")
+            return null // something must be returned
           }
-        }
+          if (logFiles.length > 1) {
+            console.error("Multiple yazi.log files found:")
+            for (const f of logFiles) {
+              console.log(f)
+            }
+          }
+
+          const file = logFiles[0]
+          assert(file)
+          const yaziLogFile = path.resolve(file.parentPath, file.name)
+
+          try {
+            const log = await readFile(yaziLogFile, "utf-8")
+            console.log(
+              `${yaziLogFile}`,
+              inspect(log.split("\n"), { maxArrayLength: null, colors: true }),
+            )
+            return null
+          } catch (err) {
+            console.error(err)
+            return null // something must be returned
+          }
+        },
       })
     },
     experimentalRunAllSpecs: true,

--- a/integration-tests/cypress/e2e/utils/startYaziApplication.ts
+++ b/integration-tests/cypress/e2e/utils/startYaziApplication.ts
@@ -24,16 +24,18 @@ export const startYaziApplication = ({
         cwdRelative: ".config/yazi",
       })
 
-      // debugging
-      // term.typeIntoTerminal("ls -al .config/yazi/plugins/easyjump.yazi/{enter}")
       term.runBlockingShellCommand({
         command: "test -f .config/yazi/plugins/easyjump.yazi/main.lua",
       })
 
       if (dir) {
-        term.typeIntoTerminal(`cd ${dir}{enter}`)
+        term.typeIntoTerminal(`cd ${dir}{enter}`, { delay: 0 })
       }
-      term.typeIntoTerminal("yazi{enter}")
+      term.typeIntoTerminal(
+        // "YAZI_LOG=debug /Users/mikavilpas/Downloads/yazi-aarch64-apple-darwin/yazi{enter}",
+        "YAZI_LOG=debug yazi{enter}",
+        { delay: 0 },
+      )
 
       return cy.wrap(term)
     })

--- a/integration-tests/cypress/support/e2e.ts
+++ b/integration-tests/cypress/support/e2e.ts
@@ -22,3 +22,9 @@ before(function () {
   // https://gist.github.com/simenbrekken/3d2248f9e50c1143bf9dbe02e67f5399?permalink_comment_id=4615046#gistcomment-4615046
   cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
 })
+
+afterEach(function () {
+  if (this.currentTest?.state === "failed") {
+    cy.task("showYaziLog")
+  }
+})


### PR DESCRIPTION
It's a bit ugly but it does the job for now

<img width="1196" height="656" alt="image" src="https://github.com/user-attachments/assets/f380d39c-269e-4bbe-a042-5520614c0d4d" />
