### PR TITLE
refactor!: require calling `require("easyjump"):setup()`

### DIFF
--- a/easyjump.yazi/main.lua
+++ b/easyjump.yazi/main.lua
@@ -232,15 +232,6 @@ local init = ya.sync(function(state)
   return state.current_num, folder.cursor, folder.offset, first_key_of_label
 end)
 
-local set_opts_default = ya.sync(function(state)
-  if state.opt_icon_fg == nil then
-    state.opt_icon_fg = "#fda1a1"
-  end
-  if state.opt_first_key_fg == nil then
-    state.opt_first_key_fg = "#df6249"
-  end
-end)
-
 local clear_state_str = ya.sync(function(state)
   state.file_pos = nil
   state.current_num = nil
@@ -249,18 +240,12 @@ end)
 
 return {
   setup = function(state, opts)
-    -- Save the user configuration to the plugin's state
-    if opts ~= nil and opts.icon_fg ~= nil then
-      state.opt_icon_fg = opts.icon_fg
-    end
-    if opts ~= nil and opts.first_key_fg ~= nil then
-      state.opt_first_key_fg = opts.first_key_fg
-    end
+    opts = opts or {}
+    state.opt_icon_fg = opts.icon_fg or "#fda1a1"
+    state.opt_first_key_fg = opts.first_key_fg or "#df6249"
   end,
 
   entry = function(_, _)
-    set_opts_default()
-
     local current_num, cursor, offset, first_key_of_label = init()
 
     if current_num == nil or current_num == 0 then

--- a/integration-tests/MyTestDirectory.ts
+++ b/integration-tests/MyTestDirectory.ts
@@ -26,11 +26,25 @@ export const MyTestDirectorySchema = z.object({
           name: z.literal("yazi/"),
           type: z.literal("directory"),
           contents: z.object({
+            "init.lua": z.object({
+              name: z.literal("init.lua"),
+              type: z.literal("file"),
+            }),
             "keymap.toml": z.object({
               name: z.literal("keymap.toml"),
               type: z.literal("file"),
             }),
           }),
+        }),
+      }),
+    }),
+    "config-modifications": z.object({
+      name: z.literal("config-modifications/"),
+      type: z.literal("directory"),
+      contents: z.object({
+        "customize_colors.lua": z.object({
+          name: z.literal("customize_colors.lua"),
+          type: z.literal("file"),
         }),
       }),
     }),
@@ -55,9 +69,12 @@ export type MyTestDirectory = MyTestDirectoryContentsSchemaType["contents"]
 
 export const testDirectoryFiles = z.enum([
   ".bashrc",
+  ".config/yazi/init.lua",
   ".config/yazi/keymap.toml",
   ".config/yazi",
   ".config",
+  "config-modifications/customize_colors.lua",
+  "config-modifications",
   "dir-with-jumpable-files/file1",
   "dir-with-jumpable-files/file2",
   "dir-with-jumpable-files",

--- a/integration-tests/cypress/e2e/easyjump.cy.ts
+++ b/integration-tests/cypress/e2e/easyjump.cy.ts
@@ -33,4 +33,28 @@ describe("easyjump", () => {
       cy.contains("[EJ]").should("not.exist")
     })
   })
+
+  it("can customize the colors", () => {
+    cy.visit("/")
+    startYaziApplication({
+      dir: "dir-with-jumpable-files",
+      configModifications: ["customize_colors.lua"],
+    }).then((term) => {
+      // wait for the yazi ui to be visible. It will select the first file
+      // automatically
+      cy.contains("NOR")
+      isFileSelected(
+        term.dir.contents["dir-with-jumpable-files"].contents.file1.name,
+      )
+
+      // activate the easyjump plugin. yazi will prompt which file to jump to
+      cy.typeIntoTerminal("i")
+
+      // verify that the color has been customized
+      const customizedColors = {
+        fg: "rgb(148, 226, 213)",
+      }
+      textIsVisibleWithColor("b", customizedColors.fg)
+    })
+  })
 })

--- a/integration-tests/test-environment/.config/yazi/init.lua
+++ b/integration-tests/test-environment/.config/yazi/init.lua
@@ -1,0 +1,1 @@
+require("easyjump"):setup()

--- a/integration-tests/test-environment/config-modifications/customize_colors.lua
+++ b/integration-tests/test-environment/config-modifications/customize_colors.lua
@@ -1,0 +1,6 @@
+local opts = {
+  icon_fg = "#94e2d5",
+  first_key_fg = "#45475a",
+}
+ya.dbg("customizing easyjump colors", opts)
+require("easyjump"):setup(opts)


### PR DESCRIPTION
# test: can customize the colors used by the plugin

# test: allow customizing the `init.lua` file in each test

The customizations are very simple - each customization is simply
appended to the end of the `init.lua` file before starting yazi.

# refactor!: require calling `require("easyjump"):setup()`

This allows simplifying the code and customizing colors at the same
time. Each user must now call `require("easyjump"):setup()` in their
`~/.config/yazi/init.lua` file.

