### PR TITLE
docs: don't specify yazi versions in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ A yazi plugin for quickly jumping to the visible files.
 A bit like [hop.nvim](https://github.com/smoka7/hop.nvim) in Neovim but for
 yazi.
 
-Tested on yazi stable
-([25.5.28](https://github.com/sxyazi/yazi/releases/tag/v25.5.28)) and yazi
-nightly.
+Tested on yazi stable and nightly. The exact versions are visible in
+[test.yml](.github/workflows/test.yml).
 
 ## Usage
 


### PR DESCRIPTION
They will fall out of date when renovate updates the version in the test file. They are not useful for users anyway.