### PR TITLE
ci: fix not being able to install yazi with rustc 1.90.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
 
       - name: Install tools with UBI
         shell: bash


### PR DESCRIPTION
# ci: fix not being able to install yazi nightly with rustc 1.90.0

https://github.com/mikavilpas/easyjump.yazi/actions/runs/19157978962/job/54762691205#step:5:100

When trying to run the CI with rustc 1.90.0, the following error occurs:

```sh
error: failed to compile `yazi-build v25.9.15 (https://github.com/sxyazi/yazi?rev=4b56e7323530224a99442d408f9e44038399b2e3#4b56e732)`, intermediate artifacts can be found at `/tmp/cargo-installBw2B6T`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.90.0 is not supported by the following package:
    yazi-shared@25.9.15 requires rustc 1.91.0
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```