### PR TITLE
chore: try to fix renovate updates triggering new releases

### DIFF
--- a/integration-tests/cypress/support/tui-sandbox.ts
+++ b/integration-tests/cypress/support/tui-sandbox.ts
@@ -48,6 +48,10 @@ export type TerminalTestApplicationContext = {
     system(): Cypress.Chainable<string>
     primary(): Cypress.Chainable<string>
   }
+
+  title: {
+    current(): Cypress.Chainable<string>
+  }
 }
 
 /** The api that can be used in tests after a Neovim instance has been started. */
@@ -99,6 +103,10 @@ export type NeovimContext = {
   clipboard: {
     system(): Cypress.Chainable<string>
     primary(): Cypress.Chainable<string>
+  }
+
+  title: {
+    current(): Cypress.Chainable<string>
   }
 }
 
@@ -169,6 +177,10 @@ Cypress.Commands.add(
             return cy.then(() => underlyingNeovim.clipboard.system())
           },
         },
+
+        title: {
+          current: () => cy.then(() => underlyingNeovim.title.get()),
+        },
       }
 
       return api
@@ -210,12 +222,11 @@ Cypress.Commands.add(
           cy.typeIntoTerminal(text, options)
         },
         clipboard: {
-          primary() {
-            return cy.then(() => terminal.clipboard.primary())
-          },
-          system() {
-            return cy.then(() => terminal.clipboard.system())
-          },
+          primary: () => cy.then(() => terminal.clipboard.primary()),
+          system: () => cy.then(() => terminal.clipboard.system()),
+        },
+        title: {
+          current: () => cy.then(() => terminal.title.get()),
         },
       }
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -7,18 +7,14 @@
     "dev": "concurrently --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start'  'pnpm cypress open --e2e --browser=electron'",
     "lint": "pnpx oxlint --type-aware && eslint --max-warnings=0 ."
   },
-  "dependencies": {
-    "@catppuccin/palette": "1.7.1",
-    "concurrently": "^9.2.1",
-    "cypress": "15.8.1",
-    "wait-on": "9.0.3",
-    "zod": "4.3.4"
-  },
   "devDependencies": {
+    "@catppuccin/palette": "1.7.1",
     "@eslint/js": "9.39.2",
     "@tui-sandbox/library": "12.3.0",
     "@types/node": "24.10.4",
     "@types/tinycolor2": "1.4.6",
+    "concurrently": "^9.2.1",
+    "cypress": "15.8.1",
     "eslint": "9.39.2",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-no-only-tests": "3.3.0",
@@ -27,6 +23,8 @@
     "tinycolor2": "1.6.0",
     "type-fest": "5.3.1",
     "typescript": "5.9.3",
-    "typescript-eslint": "8.51.0"
+    "typescript-eslint": "8.51.0",
+    "wait-on": "9.0.3",
+    "zod": "4.3.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,23 +19,10 @@ importers:
         version: 2.5.20(prettier@3.7.4)
 
   integration-tests:
-    dependencies:
+    devDependencies:
       '@catppuccin/palette':
         specifier: 1.7.1
         version: 1.7.1
-      concurrently:
-        specifier: ^9.2.1
-        version: 9.2.1
-      cypress:
-        specifier: 15.8.1
-        version: 15.8.1
-      wait-on:
-        specifier: 9.0.3
-        version: 9.0.3
-      zod:
-        specifier: 4.3.4
-        version: 4.3.4
-    devDependencies:
       '@eslint/js':
         specifier: 9.39.2
         version: 9.39.2
@@ -48,6 +35,12 @@ importers:
       '@types/tinycolor2':
         specifier: 1.4.6
         version: 1.4.6
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      cypress:
+        specifier: 15.8.1
+        version: 15.8.1
       eslint:
         specifier: 9.39.2
         version: 9.39.2
@@ -75,6 +68,12 @@ importers:
       typescript-eslint:
         specifier: 8.51.0
         version: 8.51.0(eslint@9.39.2)(typescript@5.9.3)
+      wait-on:
+        specifier: 9.0.3
+        version: 9.0.3
+      zod:
+        specifier: 4.3.4
+        version: 4.3.4
 
 packages:
 


### PR DESCRIPTION
# chore: try to fix renovate updates triggering new releases

**Issue:**

Renovate updated some testing related dependencies with a commit message
like "fix(deps): update all non-major dependencies (#162)". This
triggered a new automatic release because the semantic-release
configuration is set to create a new patch release for any "fix" commit.

https://github.com/mikavilpas/incr.nvim/releases/tag/v1.0.1

This is unwanted because these dependency updates do not affect the
actual runtime behavior of the plugin. They are only used for
integration/e2e tests.

**Solution:**

Try to prevent this from happening again by moving these dependencies
from "dependencies" to "devDependencies".

# chore: commit tui-sandbox codegen changes