### PR TITLE
ci: add testing for yazi v25.12.29 explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
             method: download
             # renovate: datasource=github-releases depName=sxyazi/yazi
             version: v26.1.4
+          - name: 25.12.29
+            method: download
+            version: v25.12.29
           - name: 25.5.31
             method: download
             version: v25.5.31

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A yazi plugin for quickly jumping to the visible files.
 A bit like [hop.nvim](https://github.com/smoka7/hop.nvim) in Neovim but for
 yazi.
 
-Tested on yazi 25.5.31, stable, and nightly. The exact versions are visible in
-[test.yml](.github/workflows/test.yml).
+Tested on yazi nightly, stable, 25.12.29, and 25.5.31. The exact versions are
+visible in [test.yml](.github/workflows/test.yml).
 
 ## Usage
 


### PR DESCRIPTION
Renovate currently updates the nightly yazi version as well as the latest stable version automatically whenever new versions are released.

Because yazi `v25.12.29` is so new, support it explicitly for some time. This will have to be added manually, and also removed manually later.