### PR TITLE
ci: add explicit testing for yazi `v26.1.4`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
           - name: 25.12.29
             method: download
             version: v25.12.29
+          - name: v26.1.4
+            method: download
+            version: v26.1.4
           - name: 25.5.31
             method: download
             version: v25.5.31

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A yazi plugin for quickly jumping to the visible files.
 A bit like [hop.nvim](https://github.com/smoka7/hop.nvim) in Neovim but for
 yazi.
 
-Tested on yazi nightly, stable, 25.12.29, and 25.5.31. The exact versions are
-visible in [test.yml](.github/workflows/test.yml).
+Tested on yazi nightly, stable, up to 25.5.31. The exact versions are visible in
+[test.yml](.github/workflows/test.yml). Also see the
+[yazi releases page](https://github.com/sxyazi/yazi/releases).
 
 ## Usage
 


### PR DESCRIPTION
# docs: state the tested yazi versions more simply

We don't have to maintain a detailed list of versions in the README, as
users can refer to the test job for that information.

# ci: add explicit testing for yazi `v26.1.4`