### PR TITLE
test: migrate away from deprecated Cypress.env() usage

### DIFF
--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -7,6 +7,7 @@ import { inspect } from "util"
 const testDirs = path.resolve(__dirname, "test-environment/testdirs")
 export default defineConfig({
   e2e: {
+    allowCypressEnv: false,
     baseUrl: "http://localhost:3000",
     setupNodeEvents(on, _config) {
       on("task", {


### PR DESCRIPTION
https://github.com/mikavilpas/easyjump.yazi/actions/runs/25650935431/job/75288924451?pr=548#step:13:34

```sh
[cypress] ❯  Verifying Cypress can run /home/runner/.cache/Cypress/15.14.2/Cypress
[cypress] ✔  Verified Cypress!       /home/runner/.cache/Cypress/15.14.2/Cypress
[cypress]
[cypress] Opening Cypress...
[cypress] Warning: The allowCypressEnv configuration option is enabled. This allows any browser code to read values from Cypress.env(). This is insecure and will be removed in a future major version.
[cypress]
[cypress] 1. Replace Cypress.env() calls with cy.env() (for sensitive values) or Cypress.expose() (for public configuration)
[cypress] 2. Set allowCypressEnv: false in your Cypress configuration to disable Cypress.env()
[cypress]
[cypress] Learn more: https://on.cypress.io/cypress-env-migration
```