### PR TITLE
fix!: remove deprecated ya.mgr_emit usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,20 +12,26 @@ jobs:
       matrix:
         yazi-version:
           # keep these up to date with the readme! 🙏🏻
+          - name: v25.5.31 # the oldest yazi version we support
+            method: download
+            version: v25.5.31
+          - name: v25.12.29
+            method: download
+            version: v25.12.29
+          - name: v26.1.4
+            method: download
+            version: v26.1.4
+          - name: v26.1.22
+            method: download
+            version: v26.1.22
+          - name: stable # the latest stable yazi version
+            method: download
+            # renovate: datasource=github-releases depName=sxyazi/yazi
+            version: v26.5.6
           - name: nightly
             method: cargo-install
             # renovate: datasource=git-refs packageName=https://github.com/sxyazi/yazi
             commit: 247f925e532236aa4e0dc6ac1a3e0a0263083ce6
-          - name: stable
-            method: download
-            # renovate: datasource=github-releases depName=sxyazi/yazi
-            version: v26.5.6
-          - name: v26.1.22
-            method: download
-            version: v26.1.22
-          - name: v26.1.4
-            method: download
-            version: v26.1.4
 
     name: "Test (yazi ${{ matrix.yazi-version.name }})"
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A yazi plugin for quickly jumping to the visible files.
 A bit like [hop.nvim](https://github.com/smoka7/hop.nvim) in Neovim but for
 yazi.
 
-Tested on yazi nightly, stable, up to v26.1.4. The exact versions are visible in
-[test.yml](.github/workflows/test.yml). Also see the
+Tested on yazi nightly, stable, up to v25.5.31. The exact versions are visible
+in [test.yml](.github/workflows/test.yml). Also see the
 [yazi releases page](https://github.com/sxyazi/yazi/releases).
 
 ## Usage

--- a/easyjump.yazi/main.lua
+++ b/easyjump.yazi/main.lua
@@ -258,10 +258,7 @@ local function read_single_key(ctx)
       local file_index = ctx.single_key_files[key]
       if file_index and file_index <= ctx.current_files_count then
         -- ya.mgr_emit is deprecated in https://github.com/sxyazi/yazi/pull/2653
-        (ya.mgr_emit or ya.emit)(
-          "arrow",
-          { file_index - ctx.cursor - 1 + ctx.offset }
-        )
+        ya.emit("arrow", { file_index - ctx.cursor - 1 + ctx.offset })
         return -- jumped
       end
       -- invalid key for current file count, wait for next
@@ -318,10 +315,7 @@ local function read_double_second_key(ctx, first_key)
       local file_index = ctx.double_key_files[double_key]
       if file_index and file_index <= ctx.current_files_count then
         -- ya.mgr_emit is deprecated in https://github.com/sxyazi/yazi/pull/2653
-        (ya.mgr_emit or ya.emit)(
-          "arrow",
-          { file_index - ctx.cursor - 1 + ctx.offset }
-        )
+        ya.emit("arrow", { file_index - ctx.cursor - 1 + ctx.offset })
         return "jumped"
       end
       -- invalid second key, wait for next


### PR DESCRIPTION
# fix!: remove deprecated ya.mgr_emit usage

BREAKING CHANGE: yazi [`v25.5.31`](https://github.com/sxyazi/yazi/releases/tag/v25.5.31) is now required (released May 30, 2025).

**Issue:**

`Yazi 26.5.6 (aa526434 2026-05-09)` shows the following warning when using `easyjump.yazi`:

```rust
│ya.mgr_emit() has been deprecated since v25.5.28 and will soon-to-be removed in a      │
│future release.                                                                        │
│                                                                                       │
│Use ya.emit() in your `easyjump.yazi` plugin instead, see #2653 for details:           │
│https://github.com/sxyazi/yazi/pull/2653                                               │
```

It's caused by the usage of `ya.mgr_emit()` for backward compatibility. The api has been deprecated since `v25.5.28` (https://github.com/sxyazi/yazi/pull/2653)

**Solution:**

Bump the minimum required yazi version to `v25.5.31` and remove the fallback to get rid of the warning at runtime.

---

# Pull request stack

- 👉🏻 **[#559](https://github.com/mikavilpas/easyjump.yazi/pull/559)** | fix!: remove deprecated ya.mgr_emit usage 👈🏻