### PR TITLE
chore!: drop support for yazi v25.5.31, require >= v25.12.29

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,7 @@ jobs:
       matrix:
         yazi-version:
           # keep these up to date with the readme! 🙏🏻
-          - name: v25.5.31 # the oldest yazi version we support
-            method: download
-            version: v25.5.31
-          - name: v25.12.29
+          - name: v25.12.29 # the oldest yazi version we support
             method: download
             version: v25.12.29
           - name: v26.1.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
           - name: v26.1.22
             method: download
             version: v26.1.22
+          - name: v26.5.6
+            method: download
+            version: v26.5.6
           - name: stable # the latest stable yazi version
             method: download
             # renovate: datasource=github-releases depName=sxyazi/yazi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A yazi plugin for quickly jumping to the visible files.
 
 A bit like [hop.nvim](https://github.com/smoka7/hop.nvim) in Neovim but for yazi.
 
-Tested on yazi nightly, stable, up to v25.5.31. The exact versions are visible in
+Tested on yazi nightly, stable, down to v25.12.29 (the oldest supported version). The exact versions are visible in
 [test.yml](.github/workflows/test.yml). Also see the [yazi releases page](https://github.com/sxyazi/yazi/releases).
 
 ## Usage

--- a/easyjump.yazi/main.lua
+++ b/easyjump.yazi/main.lua
@@ -1,4 +1,4 @@
---- @since 25.5.31
+--- @since 25.12.29
 
 -- Default hint key configuration
 -- IMPORTANT: first_keys and second_keys must NOT overlap


### PR DESCRIPTION
# chore!: drop support for yazi v25.5.31, require >= v25.12.29

# ci: add testing for yazi v26.5.6

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/easyjump.yazi/pull/764 👈🏻
  - https://github.com/mikavilpas/easyjump.yazi/pull/765