### PR TITLE
ci: don't crash on commenting PRs with "released" message

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,6 @@
   "plugins": [
     ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
-    "@semantic-release/github"
+    ["@semantic-release/github", { "successCommentCondition": false }]
   ]
 }


### PR DESCRIPTION
# ci: don't crash on commenting PRs with "released" message

**Issue:**

By default, semantic-release will comment on the PR with a message that includes the release notes. It's not useful for this project, and it seems to fail when the release cadence is low, like for us.

**Solution:**

Toggle it off.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/easyjump.yazi/pull/768 👈🏻